### PR TITLE
Allow mkdirRecursive to continue on EEXIST

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,10 +167,9 @@ function mkdirRecursive(root, chunks, mode, callback) {
       return mkdirRecursive(root, chunks, mode, callback);
     }
     return fs.mkdir(root, mode, function(err) {
-
-      if (err) {
-        return callback(err);
-      }
+      if (err && err.code !== 'EEXIST')
+          return callback(err);
+      
       return mkdirRecursive(root, chunks, mode, callback); // let's magic
     });
   });


### PR DESCRIPTION
As of Node.js v8.11.1, mkdirRecursive will prematurely abort on EEXIST encountered in loops when instead it should continue to create additional directories recursively.